### PR TITLE
Files from CF7 are not sending. FINAL_META_KET without value

### DIFF
--- a/forms-3rdparty-files.php
+++ b/forms-3rdparty-files.php
@@ -105,7 +105,7 @@ class F3i_Files_Plugin {
 			case self::VAL_ATTACH_RAW:
 			case self::VAL_ATTACH_BAS64:
 				try {
-					$bytes = file_get_contents($meta[F3i_Files_Form_Plugin::CURRENT_META_KEY]);
+					$bytes = file_get_contents($meta[F3i_Files_Form_Plugin::FINAL_META_KEY]);
 					// could throw an exception just to get the stack trace, but since we don't want to expose
 					// all of that information return the 'message' instead
 					if(false === $bytes) return array(


### PR DESCRIPTION
On function Transform you call the function file_get_contents with CURRENT_META_KEY, but if your are using CF7 doesn't works.
Because if you see on function get_files on Class F3i_CF7_Files CURRENT_META_KEY is not using, here expects that FINAL_META_KEY has a value.